### PR TITLE
Replace default Oauth server with o2r-guestlister

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+OAUTH_URL_AUTHORIZATION=http://localhost/oauth/authorize
+OAUTH_URL_TOKEN=http://webserver/oauth/token
+OAUTH_CLIENT_ID=testClient
+OAUTH_CLIENT_SECRET=testSecret
+OAUTH_URL_CALLBACK=http://localhost/api/v1/auth/login
+OAUTH_STARTUP_TEST=true
+OAUTH_STARTUP_FAIL_ON_ERROR=true
+SHIPPER_REPO_TOKENS={"download": "" }

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "o2r-inspecter"]
 	path = o2r-inspecter
 	url = https://github.com/o2r-project/o2r-inspecter
+[submodule "o2r-guestlister"]
+	path = o2r-guestlister
+	url = https://github.com/o2r-project/o2r-guestlister

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ pull_hub_images:
 	docker pull o2rproject/o2r-shipper;
 	docker pull o2rproject/o2r-substituter;
 	docker pull o2rproject/o2r-transporter;
-    docker pull o2rproject/o2r-guestlister;
+	docker pull o2rproject/o2r-guestlister;
 
 run_hub_images:
 	docker-compose up;

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ init:
 	git submodule add https://github.com/o2r-project/o2r-substituter
 	git submodule add https://github.com/o2r-project/o2r-transporter
 	git submodule add https://github.com/o2r-project/o2r-web-api
+	git submodule add https://github.com/o2r-project/o2r-guestlister
 
 update:
 	git pull --recurse-submodules
@@ -35,9 +36,10 @@ build_images:
 	cd o2r-shipper; 	docker build --tag o2r_refimpl_shipper 		.; cd ..;
 	cd o2r-substituter; docker build --tag o2r_refimpl_substituter 	.; cd ..;
 	cd o2r-transporter; docker build --tag o2r_refimpl_transporter 	.; cd ..;
+	cd o2r-guestlister; docker build --tag o2r_refimpl_guestlister 	.; cd ..;
 
 run_local:
-	OAUTH_CLIENT_ID=$(value O2R_ORCID_ID) OAUTH_CLIENT_SECRET=$(value O2R_ORCID_SECRET) OAUTH_URL_CALLBACK=$(value O2R_ORCID_CALLBACK) ZENODO_TOKEN=$(value O2R_ZENODO_TOKEN) docker-compose --file docker-compose-local.yml up;
+	docker-compose --file docker-compose-local.yml up;
 
 stop_local:
 	docker-compose --file docker-compose-local.yml down;
@@ -54,6 +56,7 @@ show_versions_local:
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}:	{{index .Config.Labels "org.label-schema.vcs-ref"}}' o2r_refimpl_shipper 	 ;
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}:	{{index .Config.Labels "org.label-schema.version"}}' o2r_refimpl_substituter ;
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}:	{{index .Config.Labels "org.label-schema.version"}}' o2r_refimpl_transporter ;
+	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}:	{{index .Config.Labels "org.label-schema.version"}}' o2r_refimpl_guestlister ;
 
 run_hub: pull_hub_images run_hub_images
 
@@ -72,9 +75,10 @@ pull_hub_images:
 	docker pull o2rproject/o2r-shipper;
 	docker pull o2rproject/o2r-substituter;
 	docker pull o2rproject/o2r-transporter;
+    docker pull o2rproject/o2r-guestlister;
 
 run_hub_images:
-	OAUTH_CLIENT_ID=$(value O2R_ORCID_ID) OAUTH_CLIENT_SECRET=$(value O2R_ORCID_SECRET) OAUTH_URL_CALLBACK=$(value O2R_ORCID_CALLBACK) ZENODO_TOKEN=$(value O2R_ZENODO_TOKEN) docker-compose up;
+	docker-compose up;
 
 show_versions_hub:
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}: {{index .Config.Labels "org.label-schema.version"}}'	   o2rproject/o2r-bouncer;
@@ -88,6 +92,7 @@ show_versions_hub:
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}: {{index .Config.Labels "org.label-schema.vcs-ref"}}'       o2rproject/o2r-shipper;
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}: {{index .Config.Labels "org.label-schema.version"}}'   o2rproject/o2r-substituter;
 	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}: {{index .Config.Labels "org.label-schema.version"}}'   o2rproject/o2r-transporter;
+	@docker inspect --format '{{index .Config.Labels "org.label-schema.name"}}: {{index .Config.Labels "org.label-schema.version"}}'   o2rproject/o2r-guestlister;
 
 clean:
 	docker ps -a | grep o2r | awk '{print $1}' | xargs docker rm -f

--- a/README-WIN.md
+++ b/README-WIN.md
@@ -3,24 +3,22 @@
 This document contains Windows-specific configuration and steps.
 
 **Please carefully read the sections "Basics" and "Prerequisites" in the file `README.md` for general information.
-In the sections "Build images from source and run" and "Build images from source and run", please be aware of the general remarks but use the commands from this file instead.
-Take a look at the "Troubleshooting" sections in this file if you run into problems.
+In the sections "Build images from source and run" and "Build images from source and run", please be aware of the general remarks but use the `docker-compose` command from this file instead of the commands using `make`.
+Take a look at the "Troubleshooting" sections in this file if you run into problems.**
 
 ## Windows with Docker for Windows
 
 [Docker for Windows](https://docs.docker.com/docker-for-windows/) is available for 64bit Windows 10 Pro, Enterprise and Education (with Hyper-V available) and on Windows Server 2016 (see [Docker Docs](https://docs.docker.com/docker-for-windows/install/#what-to-know-before-you-install)).
 
-The environmental variables must be passed separately on Windows, followed by the docker-compose commands:
+Simply run the following command to start the services:
 
 ```shell
-setx OAUTH_CLIENT_ID = "<... required ...>"
-setx OAUTH_CLIENT_SECRET = "<... required ...>"
-setx OAUTH_URL_CALLBACK = "http://localhost/api/v1/auth/login"
-setx ZENODO_TOKEN = "<... optional ...>"
 docker-compose up
 ```
 
 The services are available at `http://localhost`.
+
+Advanced configuration can be applied by editing the `.env` file or by specifying the settings as environment variables before executing the `docker-compose up` command.
 
 ### Troubleshooting
 
@@ -38,10 +36,10 @@ If your system does not meet the requirements to run Docker for Windows, you can
 
 When using Compose with Docker Toolbox/Machine on Windows, [volume paths are no longer converted from by default](https://github.com/docker/compose/releases/tag/1.9.0), but we need this conversion to be able to mount the docker volume to the o2r microservices. To re-enable this conversion for `docker-compose >= 1.9.0` set the environment variable `COMPOSE_CONVERT_WINDOWS_PATHS=1`.
 
-Also, the client's defaults (i.e. using `localhost`) does not work. We must mount a config file to point the API to the correct location, see `win/config-toolbox.js`, and use the prepared configuration file `win/docker-compose-toolbox.yml`.
+Add `COMPOSE_CONVERT_WINDOWS_PATHS=1` to the `.env` file and run:
 
 ```bash
-COMPOSE_CONVERT_WINDOWS_PATHS=1 OAUTH_CLIENT_ID=<...> OAUTH_CLIENT_SECRET=<...> OAUTH_URL_CALLBACK=<...> ZENODO_TOKEN=<...> docker-compose up
+docker-compose up
 ```
 
 The services are available at `http://<machine-ip>`.

--- a/README.md
+++ b/README.md
@@ -68,20 +68,22 @@ Run `make update` or the respective commands on your operating system to initial
 
 #### Accounts and tokens
 
-##### ORCID
+##### o2r-guestlister
 
-The reference implementation relies on [ORCID](https://orcid.org/) for authentication and authorisation.
-There is no other way to log in on the platform, therefore you must enable your installation of the reference implementation to connect with the ORCID API.
-The client credentials used by the o2r team cannot be shared publicly for security reasons.
+By default, the reference implementation uses the offline OAuth2 implementation provided by the [o2r-guestlister](https://github.com/o2r-project/o2r-guestlister). 
 
-You _must_ register an account and get a authentication tokens for public API client application with **[ORCID Sandbox](https://sandbox.orcid.org/signin)**.
+##### ORCID (optional)
+
+The reference implementation can be configured to use [ORCID](https://orcid.org/) for authentication and authorisation, replacing the offline login provided by o2r-guestlister.
+
+This requires an ORCID account which provides authentication tokens for public API client application with **[ORCID Sandbox](https://sandbox.orcid.org/signin)**.
+
 Alternatively, use your existing ORCID account and register an application as [described here](https://support.orcid.org/knowledgebase/articles/343182-register-a-public-api-client-application).
-Note that in the latter case you must adjust the URLs in the example below: remove the `sandbox.` part.
 
 In the developer tools, use any name, website URL, and description.
 Important is the `Redirect URIs` list, which must include `http://localhost` for your local installation.
 
-The client ID, client secret, and redirect URI must then be provided to the docker-compose configurations via environment variables as shown below.
+The client ID, client secret, redirect URI and the OAuth URLs have to be provided by modifying the `.env` file in the base directory. Note that environment variables provided throught the shell have priority over the `.env` file configuration. For more information on how the `.env` file works, see the docker-compose [documentation](https://docs.docker.com/compose/env-file/).
 
 ##### Repositories (optional)
 
@@ -89,6 +91,8 @@ The reference implementation can deliver the created ERC to different repositori
 These repositories also require an authentication token.
 
 - [Create access token](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fapplications%2Ftokens%2Fnew%2F) for [Zenodo](https://zenodo.org/)
+
+These tokens can be provided to the docker-compose configurations by setting them as environment variables in the `.env` file, similar to the ORCID configuration.
 
 #### Elasticsearch host preparation
 
@@ -111,9 +115,6 @@ To download all o2r source code at once, navigate to the `reference-implementati
 Once all repositories have been pulled successfully, build docker images of the microservices and run them in containers by executing:
 
 ```bash
-OAUTH_CLIENT_ID=<your orcid id> OAUTH_CLIENT_SECRET=<your orcid secret> \
-    OAUTH_URL_AUTHORIZATION=https://sandbox.orcid.org/oauth/authorize OAUTH_URL_TOKEN=https://sandbox.orcid.org/oauth/token OAUTH_URL_CALLBACK=http://localhost/api/v1/auth/login \
-    SHIPPER_REPO_TOKENS="{\"zenodo\": \"<your Zenodo token>\", \"zenodo_sandbox\": \"<your Zenodo Sandbox token>\", "download": \"\" }" \
     make build_images run_local
 ```
 
@@ -126,8 +127,6 @@ All o2r software projects have automatic builds [available on Docker Hub](https:
 The following command executes a `docker-compose` command to pull and run these images.
 
 ```bash
-O2R_ORCID_ID=<your orcid id> O2R_ORCID_SECRET=<your orcid secret> O2R_ORCID_CALLBACK=http://localhost/api/v1/auth/login \
-    SHIPPER_REPO_TOKENS="{\"zenodo\": \"<your Zenodo token>\", \"zenodo_sandbox\": \"<your Zenodo Sandbox token>\", "download": \"\" }" \
     make run_hub
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The documentation is also available online for reading, though availability may 
 | platform (web UI) | `o2r-platform` | https://github.com/o2r-project/o2r-platform|
 | shipper (microservice) | `o2r-shipper` | https://github.com/o2r-project/o2r-shipper |
 | substituter (microservice) | `o2r-substituter` | https://github.com/o2r-project/o2r-substituter |
+| guestlister (microservice) | `o2r-guestlister` | https://github.com/o2r-project/o2r-guestlister |
 | transporter (microservice) | `o2r-transporter` | https://github.com/o2r-project/o2r-transporter |
 
 ### Supported operating systems
@@ -70,11 +71,13 @@ Run `make update` or the respective commands on your operating system to initial
 
 ##### o2r-guestlister
 
-By default, the reference implementation uses the offline OAuth2 implementation provided by the [o2r-guestlister](https://github.com/o2r-project/o2r-guestlister). 
+By default, the reference implementation uses the offline OAuth2 implementation provided by the [o2r-guestlister](https://github.com/o2r-project/o2r-guestlister).
+
+This allows access to the o2r platform by selecting one of three demo users. The users represent different user roles with different levels, i.e. an admin (level 1000), an editor (level 500) and a basic author (level 100).
 
 ##### ORCID (optional)
 
-The reference implementation can be configured to use [ORCID](https://orcid.org/) for authentication and authorisation, replacing the offline login provided by o2r-guestlister.
+The reference implementation can be alternatively configured to use [ORCID](https://orcid.org/) for authentication and authorisation, replacing the offline login provided by o2r-guestlister.
 
 This requires an ORCID account which provides authentication tokens for public API client application with **[ORCID Sandbox](https://sandbox.orcid.org/signin)**.
 
@@ -93,6 +96,12 @@ These repositories also require an authentication token.
 - [Create access token](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fapplications%2Ftokens%2Fnew%2F) for [Zenodo](https://zenodo.org/)
 
 These tokens can be provided to the docker-compose configurations by setting them as environment variables in the `.env` file, similar to the ORCID configuration.
+
+Modify the `SHIPPER_REPO_TOKENS` entry in the `.env` file to include the tokens:
+
+```
+SHIPPER_REPO_TOKENS={"zenodo": "<your Zenodo token>", "zenodo_sandbox": "<your Zenodo Sandbox token>", "download": "" }
+```
 
 #### Elasticsearch host preparation
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ This allows access to the o2r platform by selecting one of three demo users. The
 
 The reference implementation can be alternatively configured to use [ORCID](https://orcid.org/) for authentication and authorisation, replacing the offline login provided by o2r-guestlister.
 
-This requires an ORCID account which provides authentication tokens for public API client application with **[ORCID Sandbox](https://sandbox.orcid.org/signin)**.
-
-Alternatively, use your existing ORCID account and register an application as [described here](https://support.orcid.org/knowledgebase/articles/343182-register-a-public-api-client-application).
+This requires an ORCID account which provides authentication tokens for public API client application with **[ORCID Sandbox](https://sandbox.orcid.org/signin)** (preferred for testing) or the registering an application as [described here](https://support.orcid.org/knowledgebase/articles/343182-register-a-public-api-client-application) with your regular ORCID account.
 
 In the developer tools, use any name, website URL, and description.
 Important is the `Redirect URIs` list, which must include `http://localhost` for your local installation.
@@ -91,6 +89,7 @@ The client ID, client secret, redirect URI and the OAuth URLs have to be provide
 ##### Repositories (optional)
 
 The reference implementation can deliver the created ERC to different repositories.
+By default only the "Download" repository is supported, i.e. users may download a complete ERC as an archive file.
 These repositories also require an authentication token.
 
 - [Create access token](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fapplications%2Ftokens%2Fnew%2F) for [Zenodo](https://zenodo.org/)

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -187,6 +187,21 @@ services:
       - INSPECTER_PORT=8091
       - DEBUGME=inspecter
 
+  guestlister:
+    image: o2rproject/o2r-guestlister:0.1.0
+    restart: unless-stopped
+    depends_on:
+      - configmongodb
+    environment:
+      - "GUESTLISTER_MONGODB=mongodb://mongodb"
+      - GUESTLISTER_PORT=8383
+      - DEBUG=guestlister
+      - OAUTH_URL_CALLBACK=${OAUTH_URL_CALLBACK}
+      - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
+      - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+      - OAUTH_URL_AUTHORIZATION=${OAUTH_URL_AUTHORIZATION}
+      - OAUTH_URL_TOKEN=${OAUTH_URL_TOKEN}
+
   platform:
     image: o2r_refimpl_platform
     restart: unless-stopped

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -188,7 +188,7 @@ services:
       - DEBUGME=inspecter
 
   guestlister:
-    image: o2rproject/o2r-guestlister:0.1.0
+    image: o2r_refimpl_guestlister
     restart: unless-stopped
     depends_on:
       - configmongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - DEBUG=informer
 
   bouncer:
-    image: o2rproject/o2r-bouncer:0.8.0
+    image: o2rproject/o2r-bouncer:0.10.1
     restart: unless-stopped
     depends_on:
       - configmongodb
@@ -191,6 +191,21 @@ services:
       - INSPECTER_PORT=8091
       - DEBUGME=inspecter
 
+  guestlister:
+    image: o2rproject/o2r-guestlister:0.1.0
+    restart: unless-stopped
+    depends_on:
+      - configmongodb
+    environment:
+      - "GUESTLISTER_MONGODB=mongodb://mongodb"
+      - GUESTLISTER_PORT=8383
+      - DEBUG=guestlister
+      - OAUTH_URL_CALLBACK=${OAUTH_URL_CALLBACK}
+      - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
+      - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+      - OAUTH_URL_AUTHORIZATION=${OAUTH_URL_AUTHORIZATION}
+      - OAUTH_URL_TOKEN=${OAUTH_URL_TOKEN}
+
   platform:
     image: o2rproject/o2r-platform:1.0.0
     restart: unless-stopped
@@ -208,6 +223,7 @@ services:
       - transporter
       - shipper
       - substituter
+      - guestlister
     volumes:
       - "./nginx.conf:/etc/nginx/nginx.conf:ro"
     ports:

--- a/nginx.conf
+++ b/nginx.conf
@@ -113,5 +113,11 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_pass http://inspecter:8091;
     }
+
+    location /oauth {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://guestlister:8383;
+    }  
   }
 }


### PR DESCRIPTION
* Adds the o2r-guestlister to the reference implementation, allowing login without specifying OAUTH configuration / registering at ORCID
* Updates documentation

Todo:

* Update certain images (meta, ...) in the two `docker-compose` files @nuest 